### PR TITLE
Replaced Java ScheduledExecutorService with Netty EventLoopGroup for custom executors

### DIFF
--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -952,7 +952,8 @@ public final class MessageClientProvider implements MqttClient {
 									.getConstructor(int.class, ThreadFactory.class)
 									.newInstance(config.numberOfThreads(), threadFactory);
 						} catch (Exception e) {
-							logHelper.warn("Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
+							logHelper.warn(
+									"Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
 							executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
 						}
 					} else {

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -22,6 +22,7 @@ import static in.bytehue.messaging.mqtt5.api.MqttMessageConstants.ConfigurationP
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getAllServicesSortedByRanking;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalService;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalServiceWithoutType;
+import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.isEpollAvailable;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -416,10 +417,6 @@ public final class MessageClientProvider implements MqttClient {
 		connectionLock.lock();
 		try {
 			init(config);
-			// [ACTIVE MODE] mark as in-progress
-			if (config.activeMode()) {
-				connectInProgress = true;
-			}
 
 			logHelper.info("Client configuration has been modified");
 
@@ -441,6 +438,9 @@ public final class MessageClientProvider implements MqttClient {
 				}
 			}
 			disconnectInProgress = true; // Mark as in progress for lifecycle
+			if (config.activeMode()) {
+				connectInProgress = true;
+			}
 		} finally {
 			connectionLock.unlock();
 		}
@@ -541,7 +541,7 @@ public final class MessageClientProvider implements MqttClient {
 				}
 				// Safe to shutdown because we are not inside this executor
 				if (asyncTaskExecutor != null) {
-					asyncTaskExecutor.shutdownNow();
+					asyncTaskExecutor.shutdown();
 				}
 			}
 		}, "mqtt-client-deactivator");
@@ -682,7 +682,7 @@ public final class MessageClientProvider implements MqttClient {
 			connectionLock.lock();
 			try {
 				if (executorToShutdown != null) {
-					executorToShutdown.shutdownGracefully(0, 0, MILLISECONDS);
+					executorToShutdown.shutdownGracefully(0, 0, MILLISECONDS).awaitUninterruptibly(2, SECONDS);
 					logHelper.debug("Custom executor shut down gracefully");
 					// Only clear the field if it hasn't been replaced by a new connection
 					if (customExecutor == executorToShutdown) {
@@ -940,8 +940,25 @@ public final class MessageClientProvider implements MqttClient {
 							        .build();
 					// @formatter:on
 
-					// Create NioEventLoopGroup locally, assign to field *inside* the lock
-					executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
+					// Dynamically check for EpollEventLoopGroup to avoid NoClassDefFoundError
+					// since it's a Linux-only native transport not available in all environments.
+					final boolean epollAvailable = isEpollAvailable(logHelper);
+
+					if (epollAvailable) {
+						logHelper.debug("Using EpollEventLoopGroup for MQTT client");
+						try {
+							Class<?> epollGroupClass = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup");
+							executorToUse = (EventLoopGroup) epollGroupClass
+									.getConstructor(int.class, ThreadFactory.class)
+									.newInstance(config.numberOfThreads(), threadFactory);
+						} catch (Exception e) {
+							logHelper.warn("Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
+							executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
+						}
+					} else {
+						logHelper.debug("Using NioEventLoopGroup for MQTT client");
+						executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
+					}
 				} else {
 					logHelper.debug("Applying Executor as Service Configuration");
 					String filter = config.executorTargetFilter().trim();
@@ -1001,14 +1018,14 @@ public final class MessageClientProvider implements MqttClient {
 				logHelper.warn("Client already connected, skipping connection attempt");
 				// Manually shutdown the executor we just created, as it won't be used
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS);
+					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS).awaitUninterruptibly(2, SECONDS);
 					logHelper.debug("Cleaning up stale local executor");
 				}
 				return CompletableFuture.completedFuture(null);
 			}
 			// Clean up the old executor before overwriting
 			if (this.customExecutor != null) {
-				this.customExecutor.shutdownGracefully(0, 0, MILLISECONDS);
+				this.customExecutor.shutdownGracefully(0, 0, MILLISECONDS).awaitUninterruptibly(2, SECONDS);
 				logHelper.debug("Cleaning up stale executor");
 			}
 			// Commit the new client and executor
@@ -1016,7 +1033,7 @@ public final class MessageClientProvider implements MqttClient {
 			if (disconnectInProgress) {
 				logHelper.warn("Disconnect initiated during connection attempt. Aborting connection.");
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS);
+					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS).awaitUninterruptibly(2, SECONDS);
 				}
 				if (clientToConnect != null) {
 					// We built it but haven't connected it. Just discard it.

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
@@ -92,6 +91,8 @@ import in.bytehue.messaging.mqtt5.api.MqttClient;
 import in.bytehue.messaging.mqtt5.provider.MessageClientProvider.Config;
 import in.bytehue.messaging.mqtt5.provider.helper.LogHelper;
 import in.bytehue.messaging.mqtt5.provider.helper.ThreadFactoryBuilder;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 
 @ProvideMessagingFeature
 @Designate(ocd = Config.class)
@@ -184,7 +185,7 @@ public final class MessageClientProvider implements MqttClient {
         @AttributeDefinition(name = "Flag to set if the threads will be daemon threads")
         boolean isDaemon() default true;
 
-        @AttributeDefinition(name = "Custom Thread Executor Service Class Name (Note that, the service should be an instance of Java Executor)")
+        @AttributeDefinition(name = "Custom Thread Executor Service Class Name (Note that, the service should be an instance of Java Executor or Netty EventLoopGroup)")
         String executorTargetClass() default "";
 
         @AttributeDefinition(name = "Custom Thread Executor Service Target Filter")
@@ -332,7 +333,7 @@ public final class MessageClientProvider implements MqttClient {
 
 	public volatile Config config;
 	private LogHelper logHelper;
-	private ScheduledExecutorService customExecutor;
+	private EventLoopGroup customExecutor;
 	private ServiceRegistration<Object> readyServiceReg;
 
 	private volatile String lastDisconnectReason;
@@ -618,7 +619,7 @@ public final class MessageClientProvider implements MqttClient {
 		final String reasonDescription;
 		final boolean useSessionExpiry;
 		final int sessionExpiryInterval;
-		final ScheduledExecutorService executorToShutdown;
+		final EventLoopGroup executorToShutdown;
 		ServiceRegistration<Object> regToClose = null;
 
 		// --- PHASE 1: Capture state ---
@@ -680,8 +681,8 @@ public final class MessageClientProvider implements MqttClient {
 			connectionLock.lock();
 			try {
 				if (executorToShutdown != null) {
-					executorToShutdown.shutdownNow();
-					logHelper.debug("Custom executor shut down");
+					executorToShutdown.shutdownGracefully();
+					logHelper.debug("Custom executor shut down gracefully");
 					// Only clear the field if it hasn't been replaced by a new connection
 					if (customExecutor == executorToShutdown) {
 						customExecutor = null;
@@ -815,7 +816,7 @@ public final class MessageClientProvider implements MqttClient {
 	private CompletableFuture<Mqtt5ConnAck> connectInternal(final String username, final byte[] password) {
 		// --- PHASE 1: PREPARATION (NO LOCK) ---
 		// Perform all service lookups and builder config *before* acquiring the lock.
-		final ScheduledExecutorService localCustomExecutor;
+		final EventLoopGroup localCustomExecutor;
 		final Mqtt5AsyncClient clientToConnect;
 
 		try {
@@ -938,9 +939,8 @@ public final class MessageClientProvider implements MqttClient {
 							        .build();
 					// @formatter:on
 
-					// Create locally, assign to field *inside* the lock
-					executorToUse = Executors.newScheduledThreadPool(config.numberOfThreads(), threadFactory);
-					((ScheduledThreadPoolExecutor) executorToUse).setRemoveOnCancelPolicy(true);
+					// Create NioEventLoopGroup locally, assign to field *inside* the lock
+					executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
 				} else {
 					logHelper.debug("Applying Executor as Service Configuration");
 					String filter = config.executorTargetFilter().trim();
@@ -955,8 +955,7 @@ public final class MessageClientProvider implements MqttClient {
 			}
 			// This local variable will be assigned to the field inside the lock
 			localCustomExecutor = (config.executorTargetClass().trim().isEmpty()
-					&& executorToUse instanceof ScheduledExecutorService) ? (ScheduledExecutorService) executorToUse
-							: null;
+					&& executorToUse instanceof EventLoopGroup) ? (EventLoopGroup) executorToUse : null;
 
 			if (config.useEnhancedAuthentication()) {
 				logHelper.debug("Applying Enhanced Authentication Configuration");
@@ -1001,14 +1000,14 @@ public final class MessageClientProvider implements MqttClient {
 				logHelper.warn("Client already connected, skipping connection attempt");
 				// Manually shutdown the executor we just created, as it won't be used
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownNow();
+					localCustomExecutor.shutdownGracefully();
 					logHelper.debug("Cleaning up stale local executor");
 				}
 				return CompletableFuture.completedFuture(null);
 			}
 			// Clean up the old executor before overwriting
 			if (this.customExecutor != null) {
-				this.customExecutor.shutdownNow();
+				this.customExecutor.shutdownGracefully();
 				logHelper.debug("Cleaning up stale executor");
 			}
 			// Commit the new client and executor
@@ -1016,7 +1015,7 @@ public final class MessageClientProvider implements MqttClient {
 			if (disconnectInProgress) {
 				logHelper.warn("Disconnect initiated during connection attempt. Aborting connection.");
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownNow();
+					localCustomExecutor.shutdownGracefully();
 				}
 				if (clientToConnect != null) {
 					// We built it but haven't connected it. Just discard it.

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -23,6 +23,7 @@ import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getAllSer
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalService;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalServiceWithoutType;
 import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
 import static org.osgi.service.condition.Condition.CONDITION_ID;
@@ -681,7 +682,7 @@ public final class MessageClientProvider implements MqttClient {
 			connectionLock.lock();
 			try {
 				if (executorToShutdown != null) {
-					executorToShutdown.shutdownGracefully();
+					executorToShutdown.shutdownGracefully(0, 0, MILLISECONDS);
 					logHelper.debug("Custom executor shut down gracefully");
 					// Only clear the field if it hasn't been replaced by a new connection
 					if (customExecutor == executorToShutdown) {
@@ -1000,14 +1001,14 @@ public final class MessageClientProvider implements MqttClient {
 				logHelper.warn("Client already connected, skipping connection attempt");
 				// Manually shutdown the executor we just created, as it won't be used
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownGracefully();
+					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS);
 					logHelper.debug("Cleaning up stale local executor");
 				}
 				return CompletableFuture.completedFuture(null);
 			}
 			// Clean up the old executor before overwriting
 			if (this.customExecutor != null) {
-				this.customExecutor.shutdownGracefully();
+				this.customExecutor.shutdownGracefully(0, 0, MILLISECONDS);
 				logHelper.debug("Cleaning up stale executor");
 			}
 			// Commit the new client and executor
@@ -1015,7 +1016,7 @@ public final class MessageClientProvider implements MqttClient {
 			if (disconnectInProgress) {
 				logHelper.warn("Disconnect initiated during connection attempt. Aborting connection.");
 				if (localCustomExecutor != null) {
-					localCustomExecutor.shutdownGracefully();
+					localCustomExecutor.shutdownGracefully(0, 0, MILLISECONDS);
 				}
 				if (clientToConnect != null) {
 					// We built it but haven't connected it. Just discard it.

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
@@ -81,6 +81,16 @@ public final class MessageHelper {
 		throw new IllegalAccessError("Non-instantiable");
 	}
 
+	public static boolean isEpollAvailable(final LogHelper logger) {
+		try {
+			final Class<?> epollClass = Class.forName("io.netty.channel.epoll.Epoll");
+			return (Boolean) epollClass.getMethod("isAvailable").invoke(null);
+		} catch (final Throwable t) {
+			logger.debug("Epoll is not available: {}", t.getMessage());
+			return false;
+		}
+	}
+
 	public static Object getServiceWithoutType(final String clazz, final String filter, final BundleContext context) {
 		try {
 			ServiceReference<?>[] references = context.getServiceReferences(clazz, filter);

--- a/in.bytehue.messaging.mqtt5.provider/src/test/java/in/bytehue/messaging/mqtt5/provider/MessageClientThreadLeakTest.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/test/java/in/bytehue/messaging/mqtt5/provider/MessageClientThreadLeakTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2020-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package in.bytehue.messaging.mqtt5.provider;
+
+import static in.bytehue.messaging.mqtt5.provider.TestHelper.waitForMqttConnectionReady;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import aQute.launchpad.Launchpad;
+import aQute.launchpad.LaunchpadBuilder;
+import aQute.launchpad.Service;
+import aQute.launchpad.junit.LaunchpadRunner;
+import in.bytehue.messaging.mqtt5.api.MqttClient;
+
+/**
+ * Integration test to validate that MessageClientProvider does not leak threads
+ * when repeatedly connecting and disconnecting with a custom executor.
+ */
+@RunWith(LaunchpadRunner.class)
+public class MessageClientThreadLeakTest {
+
+    @Service
+    private Launchpad launchpad;
+
+    @Service
+    private MqttClient client;
+
+    @Service
+    private ConfigurationAdmin configAdmin;
+
+    @SuppressWarnings("resource")
+    static LaunchpadBuilder builder = new LaunchpadBuilder().bndrun("test.bndrun").export("sun.misc");
+
+    @Before
+    public void setup() throws Exception {
+        // Configure the client to use a custom executor (which triggers the local thread pool creation)
+        final Configuration config = configAdmin.getConfiguration("in.bytehue.messaging.client", "?");
+        final Dictionary<String, Object> props = new Hashtable<>();
+        props.put("server", "localhost");
+        props.put("useCustomExecutor", true);
+        props.put("numberOfThreads", 2); // Small thread pool
+        props.put("threadNamePrefix", "mqtt-leak-test");
+        config.updateIfDifferent(props);
+
+        waitForMqttConnectionReady(launchpad);
+    }
+
+    @Test
+    public void testRepeatedConnectDisconnectDoesNotLeakThreads() throws Exception {
+        // Verify initial state
+        assertThat(client.isConnected()).isTrue();
+
+        // Perform 10 iterations of connect/disconnect
+        final int iterations = 10;
+        for (int i = 0; i < iterations; i++) {
+            client.disconnect().join();
+            assertThat(client.isConnected()).isFalse();
+
+            client.connect().join();
+            assertThat(client.isConnected()).isTrue();
+        }
+
+        // Wait a short moment to ensure threads from the old executors have time to spin down
+        Thread.sleep(1000);
+
+        // Count how many "mqtt-leak-test" threads are currently alive
+        long leakTestThreadCount = Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.getName().startsWith("mqtt-leak-test"))
+                .filter(Thread::isAlive)
+                .count();
+
+        // If the leak is present, there will be 10+ threads alive because every disconnect
+        // fails to kill the Netty EventLoop.
+        // If the fix is active, there should be exactly the number of threads from the CURRENT connection (<= 2).
+        assertThat(leakTestThreadCount).isLessThanOrEqualTo(2);
+    }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,53 +16,18 @@
 #-------------------------------------------------------------------------------
 
 # --- CONFIGURATION ---
-HIVEMQ_VERSION="2023.5"
-HIVEMQ_ZIP="hivemq-ce-${HIVEMQ_VERSION}.zip"
-HIVEMQ_DIR="hivemq-ce-${HIVEMQ_VERSION}"
-HIVEMQ_URL="https://github.com/hivemq/hivemq-community-edition/releases/download/${HIVEMQ_VERSION}/${HIVEMQ_ZIP}"
-
 MQTT_PORT=1883
 PID_FILE="hivemq_pid"
-
-# --- 0. PRE-FLIGHT CHECKS ---
-
-# A. Verify Java 17
-JAVA_VER=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1)
-if [[ "$JAVA_VER" != "17" ]]; then
-  echo "❌ Error: Java 17 is required. Found Java $JAVA_VER"
-  exit 1
-fi
-
-# B. Kill existing HiveMQ processes for a clean start
-echo "--- [CLEANUP] Scrubbing existing HiveMQ processes ---"
-EXISTING_PIDS=$(pgrep -f "$HIVEMQ_DIR")
-
-if [ ! -z "$EXISTING_PIDS" ]; then
-  echo "Stopping existing HiveMQ process(es): $EXISTING_PIDS"
-  echo "$EXISTING_PIDS" | xargs kill -9 2>/dev/null
-  sleep 2
-fi
-
-# Final port check
-if nc -z localhost $MQTT_PORT; then
-  echo "❌ Error: Port $MQTT_PORT is occupied. Please stop any other MQTT services."
-  exit 1
-fi
 
 [ -f "$PID_FILE" ] && rm "$PID_FILE"
 
 # --- 1. SETUP BROKER ---
-if [ ! -d "$HIVEMQ_DIR" ]; then
-  echo "--- [SETUP] Downloading HiveMQ CE ${HIVEMQ_VERSION} ---"
-  curl -L -O "$HIVEMQ_URL"
-  unzip -q "$HIVEMQ_ZIP"
-  rm "$HIVEMQ_ZIP"
+./scripts/start-broker.sh --daemon
+if [ ! -f "$PID_FILE" ]; then
+  echo "❌ Error: $PID_FILE not found. Broker failed to start."
+  exit 1
 fi
-
-echo "--- [SETUP] Starting HiveMQ Broker (Java 17) ---"
-./"$HIVEMQ_DIR"/bin/run.sh > hivemq.log 2>&1 &
-HIVEMQ_PID=$!
-echo $HIVEMQ_PID > "$PID_FILE"
+HIVEMQ_PID=$(cat "$PID_FILE")
 
 # Wait for Startup
 echo "Waiting for HiveMQ..."

--- a/scripts/start-broker.sh
+++ b/scripts/start-broker.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright 2021-2026 Amit Kumar Mondal
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
+
+# --- CONFIGURATION ---
+HIVEMQ_VERSION="2023.5"
+HIVEMQ_ZIP="hivemq-ce-${HIVEMQ_VERSION}.zip"
+HIVEMQ_DIR="hivemq-ce-${HIVEMQ_VERSION}"
+HIVEMQ_URL="https://github.com/hivemq/hivemq-community-edition/releases/download/${HIVEMQ_VERSION}/${HIVEMQ_ZIP}"
+
+MQTT_PORT=1883
+PID_FILE="hivemq_pid"
+
+DAEMON_MODE=0
+if [ "$1" == "--daemon" ]; then
+  DAEMON_MODE=1
+fi
+
+# --- 0. PRE-FLIGHT CHECKS ---
+
+# A. Verify Java 17
+JAVA_VER=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1)
+if [[ "$JAVA_VER" != "17" ]]; then
+  echo "⚠️  Warning: HiveMQ officially requires Java 17. Found Java $JAVA_VER."
+  echo "Attempting to start anyway..."
+fi
+
+# B. Kill existing HiveMQ processes for a clean start
+echo "--- [CLEANUP] Scrubbing existing HiveMQ processes ---"
+EXISTING_PIDS=$(pgrep -f "$HIVEMQ_DIR")
+
+if [ ! -z "$EXISTING_PIDS" ]; then
+  echo "Stopping existing HiveMQ process(es): $EXISTING_PIDS"
+  echo "$EXISTING_PIDS" | xargs kill -9 2>/dev/null
+  sleep 2
+fi
+
+# Final port check
+if nc -z localhost $MQTT_PORT; then
+  echo "❌ Error: Port $MQTT_PORT is occupied. Please stop any other MQTT services."
+  exit 1
+fi
+
+# --- 1. SETUP BROKER ---
+if [ ! -d "$HIVEMQ_DIR" ]; then
+  echo "--- [SETUP] Downloading HiveMQ CE ${HIVEMQ_VERSION} ---"
+  curl -L -O "$HIVEMQ_URL"
+  unzip -q "$HIVEMQ_ZIP"
+  rm "$HIVEMQ_ZIP"
+fi
+
+echo "--- [SETUP] Starting HiveMQ Broker ---"
+if [ "$DAEMON_MODE" -eq 1 ]; then
+  echo "✅ Broker will run in the background."
+  echo "--------------------------------------------------------"
+  cd "$HIVEMQ_DIR"
+  ./bin/run.sh > ../hivemq.log 2>&1 &
+  echo $! > "../$PID_FILE"
+else
+  echo "✅ Broker will run in the foreground. Press Ctrl+C to stop it."
+  echo "--------------------------------------------------------"
+  # Run in foreground so Eclipse users can see logs and kill it easily
+  cd "$HIVEMQ_DIR"
+  exec ./bin/run.sh
+fi


### PR DESCRIPTION
Switched from using a standard Java ScheduledThreadPoolExecutor to Netty's NioEventLoopGroup to better integrate with the underlying MQTT client's threading model. This change ensures that custom executors are shut down gracefully, preventing potential thread leaks during connection and disconnection cycles.

Fixes https://github.com/amitjoy/osgi-messaging/issues/74