### PR TITLE
Forced immediate shutdown of the async task executor

### DIFF
--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -22,7 +22,7 @@ import static in.bytehue.messaging.mqtt5.api.MqttMessageConstants.ConfigurationP
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getAllServicesSortedByRanking;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalService;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalServiceWithoutType;
-import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.isEpollAvailable;
+import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.createEventLoopGroup;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -94,7 +94,6 @@ import in.bytehue.messaging.mqtt5.provider.MessageClientProvider.Config;
 import in.bytehue.messaging.mqtt5.provider.helper.LogHelper;
 import in.bytehue.messaging.mqtt5.provider.helper.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 
 @ProvideMessagingFeature
 @Designate(ocd = Config.class)
@@ -940,26 +939,7 @@ public final class MessageClientProvider implements MqttClient {
 							        .build();
 					// @formatter:on
 
-					// Dynamically check for EpollEventLoopGroup to avoid NoClassDefFoundError
-					// since it's a Linux-only native transport not available in all environments.
-					final boolean epollAvailable = isEpollAvailable(logHelper);
-
-					if (epollAvailable) {
-						logHelper.debug("Using EpollEventLoopGroup for MQTT client");
-						try {
-							Class<?> epollGroupClass = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup");
-							executorToUse = (EventLoopGroup) epollGroupClass
-									.getConstructor(int.class, ThreadFactory.class)
-									.newInstance(config.numberOfThreads(), threadFactory);
-						} catch (Exception e) {
-							logHelper.warn(
-									"Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
-							executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
-						}
-					} else {
-						logHelper.debug("Using NioEventLoopGroup for MQTT client");
-						executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
-					}
+					executorToUse = createEventLoopGroup(config.numberOfThreads(), threadFactory, logHelper);
 				} else {
 					logHelper.debug("Applying Executor as Service Configuration");
 					String filter = config.executorTargetFilter().trim();

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -541,7 +541,7 @@ public final class MessageClientProvider implements MqttClient {
 				}
 				// Safe to shutdown because we are not inside this executor
 				if (asyncTaskExecutor != null) {
-					asyncTaskExecutor.shutdown();
+					asyncTaskExecutor.shutdownNow();
 				}
 			}
 		}, "mqtt-client-deactivator");

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
@@ -47,6 +47,10 @@ import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import java.util.concurrent.ThreadFactory;
+
 import org.osgi.dto.DTO;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -88,6 +92,24 @@ public final class MessageHelper {
 		} catch (final Throwable t) {
 			logger.debug("Epoll is not available: {}", t.getMessage());
 			return false;
+		}
+	}
+
+	public static EventLoopGroup createEventLoopGroup(final int nThreads, final ThreadFactory threadFactory,
+			final LogHelper logHelper) {
+		if (isEpollAvailable(logHelper)) {
+			logHelper.debug("Using EpollEventLoopGroup for MQTT client");
+			try {
+				final Class<?> epollGroupClass = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup");
+				return (EventLoopGroup) epollGroupClass.getConstructor(int.class, ThreadFactory.class)
+						.newInstance(nThreads, threadFactory);
+			} catch (final Exception e) {
+				logHelper.warn("Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
+				return new NioEventLoopGroup(nThreads, threadFactory);
+			}
+		} else {
+			logHelper.debug("Using NioEventLoopGroup for MQTT client");
+			return new NioEventLoopGroup(nThreads, threadFactory);
 		}
 	}
 


### PR DESCRIPTION
Changed the shutdown method to shutdownNow() to ensure the async task executor terminates immediately during client deactivation.

Fixes #74
