### PR TITLE
Removed Epoll support and simplified event loop group creation

### DIFF
--- a/cnf/maven/build.maven
+++ b/cnf/maven/build.maven
@@ -53,7 +53,6 @@ io.netty:netty-handler:4.1.122.Final
 io.netty:netty-handler-proxy:4.1.122.Final
 io.netty:netty-resolver:4.1.122.Final
 io.netty:netty-transport:4.1.122.Final
-io.netty:netty-transport-native-epoll:4.1.122.Final
 io.netty:netty-transport-native-unix-common:4.1.122.Final
 io.reactivex.rxjava2:rxjava:2.2.21
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject:1_3

--- a/in.bytehue.messaging.mqtt5.provider/bnd.bnd
+++ b/in.bytehue.messaging.mqtt5.provider/bnd.bnd
@@ -27,7 +27,6 @@ Bundle-Description             : An OSGi Messaging Adapter for the MQTT 5.0 prot
 	io.netty.handler-proxy;maven-scope=provided,\
 	io.netty.resolver;maven-scope=provided,\
 	io.netty.transport;maven-scope=provided,\
-	io.netty.transport-native-epoll;maven-scope=provided,\
 	io.netty.transport-native-unix-common;maven-scope=provided,\
 	io.reactivex.rxjava2.rxjava;maven-scope=provided,\
 	org.apache.servicemix.bundles.javax-inject;maven-scope=provided,\

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/MessageClientProvider.java
@@ -22,7 +22,6 @@ import static in.bytehue.messaging.mqtt5.api.MqttMessageConstants.ConfigurationP
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getAllServicesSortedByRanking;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalService;
 import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.getOptionalServiceWithoutType;
-import static in.bytehue.messaging.mqtt5.provider.helper.MessageHelper.createEventLoopGroup;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -94,6 +93,7 @@ import in.bytehue.messaging.mqtt5.provider.MessageClientProvider.Config;
 import in.bytehue.messaging.mqtt5.provider.helper.LogHelper;
 import in.bytehue.messaging.mqtt5.provider.helper.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 
 @ProvideMessagingFeature
 @Designate(ocd = Config.class)
@@ -939,7 +939,7 @@ public final class MessageClientProvider implements MqttClient {
 							        .build();
 					// @formatter:on
 
-					executorToUse = createEventLoopGroup(config.numberOfThreads(), threadFactory, logHelper);
+					executorToUse = new NioEventLoopGroup(config.numberOfThreads(), threadFactory);
 				} else {
 					logHelper.debug("Applying Executor as Service Configuration");
 					String filter = config.executorTargetFilter().trim();

--- a/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
+++ b/in.bytehue.messaging.mqtt5.provider/src/main/java/in/bytehue/messaging/mqtt5/provider/helper/MessageHelper.java
@@ -47,10 +47,6 @@ import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import java.util.concurrent.ThreadFactory;
-
 import org.osgi.dto.DTO;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -83,34 +79,6 @@ public final class MessageHelper {
 
 	private MessageHelper() {
 		throw new IllegalAccessError("Non-instantiable");
-	}
-
-	public static boolean isEpollAvailable(final LogHelper logger) {
-		try {
-			final Class<?> epollClass = Class.forName("io.netty.channel.epoll.Epoll");
-			return (Boolean) epollClass.getMethod("isAvailable").invoke(null);
-		} catch (final Throwable t) {
-			logger.debug("Epoll is not available: {}", t.getMessage());
-			return false;
-		}
-	}
-
-	public static EventLoopGroup createEventLoopGroup(final int nThreads, final ThreadFactory threadFactory,
-			final LogHelper logHelper) {
-		if (isEpollAvailable(logHelper)) {
-			logHelper.debug("Using EpollEventLoopGroup for MQTT client");
-			try {
-				final Class<?> epollGroupClass = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup");
-				return (EventLoopGroup) epollGroupClass.getConstructor(int.class, ThreadFactory.class)
-						.newInstance(nThreads, threadFactory);
-			} catch (final Exception e) {
-				logHelper.warn("Failed to instantiate EpollEventLoopGroup, falling back to NioEventLoopGroup", e);
-				return new NioEventLoopGroup(nThreads, threadFactory);
-			}
-		} else {
-			logHelper.debug("Using NioEventLoopGroup for MQTT client");
-			return new NioEventLoopGroup(nThreads, threadFactory);
-		}
 	}
 
 	public static Object getServiceWithoutType(final String clazz, final String filter, final BundleContext context) {


### PR DESCRIPTION
Removed the conditional logic for Epoll availability and the associated netty-transport-native-epoll dependency. The MQTT client now explicitly uses NioEventLoopGroup for its executor, simplifying the codebase and dependency management.

Fixed #74