### PR TITLE
Cleared sonatype staging and cache directories between bundle releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -68,7 +68,13 @@ rm -rf cnf/target/sonatype-staging/* 2>/dev/null || true
 
 echo "🏁 Releasing Bundles"
 ./gradlew :in.bytehue.messaging.mqtt5.api:release
+
+rm -rf cnf/cache/sonatype-release/* 2>/dev/null || true
+rm -rf cnf/target/sonatype-staging/* 2>/dev/null || true
 ./gradlew :in.bytehue.messaging.mqtt5.provider:release
+
+rm -rf cnf/cache/sonatype-release/* 2>/dev/null || true
+rm -rf cnf/target/sonatype-staging/* 2>/dev/null || true
 ./gradlew :in.bytehue.messaging.mqtt5.remote.adapter:release
 
 baseline_version=$(cat cnf/version/current.version)


### PR DESCRIPTION
Ensured a clean environment by removing leftover artifacts from the cache and staging directories before releasing individual bundles in the release script.

Fixes #81